### PR TITLE
bug fix: check for correct arg type was throwing error

### DIFF
--- a/R/cli.R
+++ b/R/cli.R
@@ -606,7 +606,7 @@ validate_arg <- function(cli_arg, arg_val){
                        q(save = "no", status = 1)
                    })
     }
-    if(!cli_arg$type %in% c(typeof(arg_val), class(arg_val))){  
+    if(!cli_arg$type %in% c(typeof(arg_val), class(arg_val), "file", "path")){  
         cat(paste0("\nERROR: ", cli_arg$name, " should be of type ", 
                    toupper(cli_arg$type), ", not ", typeof(arg_val), "\n\n"))
         q(save = "no", status = 1)


### PR DESCRIPTION
The check did not take into account argument types 'file' and 'path' and the fact that those strings do not match the actual data type of the argument, which is "character"